### PR TITLE
「検査実施数」の可視化期間を２ヶ月に変更 #66

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -142,7 +142,26 @@ export default {
     const querentsGraph = formatGraph(Data.querents.data)
     // 福岡県営地下鉄の利用者数の推移
     const metroGraph = MetroData
+
     // 検査実施日別状況
+    // 最新の日付から2ヶ月前の日付を mm/dd の文字列で取得（05/18 => 03/18）
+    const date_2MonthsAgo = (() => {
+      const tmp_date = new Date(Data.inspections_summary.date.slice(5,10));
+      tmp_date.setMonth(tmp_date.getMonth() - 2);
+      const m = ("00" + (tmp_date.getMonth()+1)).slice(-2);
+      const d = ("00" + tmp_date.getDate()).slice(-2);
+      return m + "/" + d;
+    })();
+    // 可視化する最初（最古）のデータが入っているインデックスを取得
+    // 例：最新の日付が05/18 => 03/19のデータが入っているインデックスを取得
+    const inspectionsLabels_startIndex = Data.inspections_summary.labels.findIndex((element) => {
+      return (element > date_2MonthsAgo);
+    });
+    // 変数から可視化しないデータを削除
+    Data.inspections_summary.labels.splice(0,inspectionsLabels_startIndex)
+    Data.inspections_summary.data['福岡市'].splice(0,inspectionsLabels_startIndex),
+    Data.inspections_summary.data['北九州市'].splice(0,inspectionsLabels_startIndex),
+    Data.inspections_summary.data['福岡県※'].splice(0,inspectionsLabels_startIndex)
     const inspectionsGraph = [
       Data.inspections_summary.data['福岡市'],
       Data.inspections_summary.data['北九州市'],
@@ -154,6 +173,7 @@ export default {
       '福岡県※'
     ]
     const inspectionsLabels = Data.inspections_summary.labels
+
     // 死亡者数
     // #MEMO: 今後使う可能性あるので一時コメントアウト
     // const fatalitiesTable = formatTable(

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -145,23 +145,23 @@ export default {
 
     // 検査実施日別状況
     // 最新の日付から2ヶ月前の日付を mm/dd の文字列で取得（05/18 => 03/18）
-    const date_2MonthsAgo = (() => {
-      const tmp_date = new Date(Data.inspections_summary.date.slice(5,10));
-      tmp_date.setMonth(tmp_date.getMonth() - 2);
-      const m = ("00" + (tmp_date.getMonth()+1)).slice(-2);
-      const d = ("00" + tmp_date.getDate()).slice(-2);
-      return m + "/" + d;
-    })();
+    const TwoMonthsAgo = (() => {
+      const tmpDate = new Date(Data.inspections_summary.date.slice(5,10))
+      tmpDate.setMonth(tmpDate.getMonth() - 2)
+      const m = ('00' + (tmpDate.getMonth()+1)).slice(-2)
+      const d = ('00' + tmpDate.getDate()).slice(-2)
+      return m + '/' + d
+    })()
     // 可視化する最初（最古）のデータが入っているインデックスを取得
     // 例：最新の日付が05/18 => 03/19のデータが入っているインデックスを取得
-    const inspectionsLabels_startIndex = Data.inspections_summary.labels.findIndex((element) => {
-      return (element > date_2MonthsAgo);
-    });
+    const startIndex = Data.inspections_summary.labels.findIndex(element => {
+      return element > TwoMonthsAgo
+    })
     // 変数から可視化しないデータを削除
-    Data.inspections_summary.labels.splice(0,inspectionsLabels_startIndex)
-    Data.inspections_summary.data['福岡市'].splice(0,inspectionsLabels_startIndex),
-    Data.inspections_summary.data['北九州市'].splice(0,inspectionsLabels_startIndex),
-    Data.inspections_summary.data['福岡県※'].splice(0,inspectionsLabels_startIndex)
+    Data.inspections_summary.labels.splice(0,startIndex)
+    Data.inspections_summary.data['福岡市'].splice(0,startIndex),
+    Data.inspections_summary.data['北九州市'].splice(0,startIndex),
+    Data.inspections_summary.data['福岡県※'].splice(0,startIndex)
     const inspectionsGraph = [
       Data.inspections_summary.data['福岡市'],
       Data.inspections_summary.data['北九州市'],

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -146,9 +146,9 @@ export default {
     // 検査実施日別状況
     // 最新の日付から2ヶ月前の日付を mm/dd の文字列で取得（05/18 => 03/18）
     const TwoMonthsAgo = (() => {
-      const tmpDate = new Date(Data.inspections_summary.date.slice(5,10))
+      const tmpDate = new Date(Data.inspections_summary.date.slice(5, 10))
       tmpDate.setMonth(tmpDate.getMonth() - 2)
-      const m = ('00' + (tmpDate.getMonth()+1)).slice(-2)
+      const m = ('00' + (tmpDate.getMonth() + 1)).slice(-2)
       const d = ('00' + tmpDate.getDate()).slice(-2)
       return m + '/' + d
     })()
@@ -158,10 +158,10 @@ export default {
       return element > TwoMonthsAgo
     })
     // 変数から可視化しないデータを削除
-    Data.inspections_summary.labels.splice(0,startIndex)
-    Data.inspections_summary.data['福岡市'].splice(0,startIndex),
-    Data.inspections_summary.data['北九州市'].splice(0,startIndex),
-    Data.inspections_summary.data['福岡県※'].splice(0,startIndex)
+    Data.inspections_summary.labels.splice(0, startIndex)
+    Data.inspections_summary.data['福岡市'].splice(0, startIndex)
+    Data.inspections_summary.data['北九州市'].splice(0, startIndex)
+    Data.inspections_summary.data['福岡県※'].splice(0, startIndex)
     const inspectionsGraph = [
       Data.inspections_summary.data['福岡市'],
       Data.inspections_summary.data['北九州市'],


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- 検査実施数に可視化する日数を固定する #66 

## ⛏ 変更内容 / Details of Changes
- 「検査実施数」の可視化期間を２ヶ月に変更に変更しました。
- コードの修正箇所は index.vue の変数作成部分です。
- これで大丈夫そうならマージをお願いします。
- マージ後はこのissueをcloseしてもらって大丈夫です。（マージを私が確認した場合は私がcloseします）

## 📸 スクリーンショット / Screenshots
<img width="405" alt="スクリーンショット 2020-05-18 19 47 22" src="https://user-images.githubusercontent.com/16728090/82204766-70581980-9940-11ea-8012-572ba3e88952.png">

