### PR TITLE
検査実施数の可視化範囲を２ヶ月に限定

### DIFF
--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -93,7 +93,7 @@ export default {
     
     // 最新の日付から2ヶ月前の日付を mm/dd の文字列で取得（05/18 => 03/18）
     const TwoMonthsAgo = (() => {
-      let tmpDate = new Date(this.date)
+      const tmpDate = new Date(this.date)
       tmpDate.setMonth(tmpDate.getMonth() - 2)
       const m = ('00' + (tmpDate.getMonth() + 1)).slice(-2)
       const d = ('00' + tmpDate.getDate()).slice(-2)


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- 検査実施数に可視化する日数を固定する #66

## ⛏ 変更内容 / Details of Changes
- 変更ファイルはTimeStackedBarChart.vueのみです。
- 変数の処理を変更し、描画するデータを２ヶ月分になるように修正しました。
- 東京版のような横軸スクロール機能には対応しておりませんが、その分動作が軽いのではと思ってます（描画するデータが少ないため）。

## 📸 スクリーンショット / Screenshots
<img width="350" alt="スクリーンショット 2020-05-20 12 47 56" src="https://user-images.githubusercontent.com/16728090/82403223-4b2aee80-9a99-11ea-88f6-d46a2717cfbd.png">
