### PR TITLE
凡例の色を統一（ISSUES:#83）

### DIFF
--- a/components/AreaChart.vue
+++ b/components/AreaChart.vue
@@ -77,6 +77,7 @@
 import DataView from '@/components/DataView.vue'
 import DoughnutChart from '@/components/chart/DoughnutChart.js'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import chartColor from '@/utils/colors'
 
 export default {
   components: {
@@ -187,7 +188,7 @@ export default {
             data: this.chartData.map(d => {
               return d.cumulative
             }),
-            backgroundColor: ['#80CAFF', '#D9EFFF', '#C1E5FF', '#45c1f0'],
+            backgroundColor: chartColor,
             borderColor: '#7f7f7f',
             borderWidth: 0.3
           }

--- a/components/TimeBarPatientsChart.vue
+++ b/components/TimeBarPatientsChart.vue
@@ -56,6 +56,7 @@ import DataSelector from '@/components/DataSelector.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import DateSelectSlider from '@/components/DateSelectSlider.vue'
 import makeRecentData from '@/utils/makeRecentData'
+import chartColor from '@/utils/colors'
 
 export default {
   components: {
@@ -208,7 +209,7 @@ export default {
       }
     },
     displayData() {
-      const colorArray = ['#80caff', '#95e7ec', '#0e98da', '#8fc1e3']
+      const colorArray = chartColor
       const displayLabel = []
       for (let i = this.graphRange[0]; i <= this.graphRange[1]; i++) {
         displayLabel.push(this.labels[i])

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -54,6 +54,7 @@ import DataSelector from '@/components/DataSelector.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import DateSelectSlider from '@/components/DateSelectSlider.vue'
 import makeRecentData from '@/utils/makeRecentData'
+import chartColor from '@/utils/colors'
 
 export default {
   components: {
@@ -176,7 +177,7 @@ export default {
       }
     },
     displayData() {
-      const colorArray = ['#325685', '#81A3CF', '#B8CBE4']
+      const colorArray = chartColor.slice(0,3)
       const displayLabel = []
       for (let i = this.graphRange[0]; i <= this.graphRange[1]; i++) {
         displayLabel.push(this.labels[i])

--- a/utils/colors.ts
+++ b/utils/colors.ts
@@ -1,0 +1,8 @@
+const chartColor: string[] = [
+    '#80CAFF', // 福岡市
+    '#D9EFFF', // 北九州市
+    '#C1E5FF', // 福岡県（福岡市・北九州市以外）
+    '#45c1f0'  // それ以外  
+]
+
+export default chartColor


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- 凡例の色を統一（ISSUES:#83）

## ⛏ 変更内容 / Details of Changes
- 福岡市、北九州市、福岡県、その他　に関するグラフに関して、使用する色を円グラフで使われているものに統一
- 各グラフで使用する色は /utils/color.ts で定義しており、このファイル中の変数を修正すると各グラフの色を変更できる

## 📸 スクリーンショット / Screenshots
![chart1](https://user-images.githubusercontent.com/16728090/88448716-9c7da280-ce7b-11ea-81c8-d699cc59bf6c.PNG)
![chart2](https://user-images.githubusercontent.com/16728090/88448720-9e476600-ce7b-11ea-85aa-c8cacc90b77f.PNG)
![chart3](https://user-images.githubusercontent.com/16728090/88448721-a0112980-ce7b-11ea-8675-fb39a182efcb.PNG)
